### PR TITLE
Doc

### DIFF
--- a/docs/encryption.rst
+++ b/docs/encryption.rst
@@ -11,7 +11,7 @@ Embedded PSKC encryption is handled inside the :class:`Encryption` class that
 defines encryption key or means of deriving keys. It is accessed from the
 :attr:`~pskc.PSKC.encryption` attribute of a :class:`~pskc.PSKC` instance::
 
-   >>> rom binascii import a2b_hex
+   >>> from binascii import a2b_hex
    >>> from pskc import PSKC
    >>> pskc = PSKC('somefile.pskcxml')
    >>> pskc.encryption.key = a2b_hex('12345678901234567890123456789012')

--- a/pskc2csv.py
+++ b/pskc2csv.py
@@ -20,6 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA
 
+from __future__ import print_function
 import argparse
 import csv
 import operator
@@ -53,7 +54,7 @@ class VersionAction(argparse.Action):
             help=help)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        print version_string
+        print(version_string)
         parser.exit()
 
 epilog = '''


### PR DESCRIPTION
Hi Arthur,

Here are two more minimal patches:
- in `docs/encryption.rst`, a letter is missing in the example
  (you have `rom` for `from`).
- I changed the naked `print` statement to a function in
  `pskc2csv.py` and imported `print_function` so that the
  program works on both Python 2 and 3.

On the example on your homepage for `python-pskc`, you could
maybe write that pre-shared keys must be set on
`pskc.encryption.key` and that `derive_key()` raises.  This is
in the doc but one has to go look for it.

Best regards and thank you again for your library, it really did
buy me a lot of time!

Mathias
